### PR TITLE
use table model instead of table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ Insert and update batch (bulk) in laravel
 
 NOTE: [Click to install the previous version 1.0](https://github.com/mavinoo/laravelBatch/tree/v1.0).
 
-
 # Service Provider
 file app.php in array providers :
 
 `Mavinoo\LaravelBatch\LaravelBatchServiceProvider::class,`
-
 
 # Aliases
 file app.php in array aliases :
@@ -22,8 +20,9 @@ file app.php in array aliases :
 # Example Update 1
 
 ```
-$table = 'users';
+use App\Models\User;
 
+$userInstance = new User;
 $value = [
      [
          'id' => 1,
@@ -36,19 +35,17 @@ $value = [
          'nickname' => 'Ghanbari'
      ] ,
 ];
-
 $index = 'id';
 
-
-Batch::update($table, $value, $index);
+Batch::update($userInstance, $value, $index);
 ```
-
 
 # Example Update 2
 
 ```
-$table = 'users';
+use App\Models\User;
 
+$userInstance = new User;
 $value = [
      [
          'id' => 1,
@@ -69,18 +66,17 @@ $value = [
          'username' => 'mavinoo'
      ]
 ];
-
 $index = 'id';
 
-Batch::update($table, $value, $index);
+Batch::update($userInstance, $value, $index);
 ```
-
 
 # Example Insert
 
 ```
-$table = 'users';
+use App\Models\User;
 
+$userInstance = new User;
 $columns = [
      'firstName',
      'lastName',
@@ -88,7 +84,6 @@ $columns = [
      'isActive',
      'status',
 ];
-
 $values = [
      [
          'Mohammad',
@@ -112,10 +107,9 @@ $values = [
          '0',
      ] ,
 ];
-
 $batchSize = 500; // insert 500 (default), 100 minimum rows in one query
 
-$result = Batch::insert($table, $columns, $values, $batchSize);
+$result = Batch::insert($userInstance, $columns, $values, $batchSize);
 ```
 
 ```

--- a/src/LaravelBatch.php
+++ b/src/LaravelBatch.php
@@ -4,7 +4,6 @@ namespace Mavinoo\LaravelBatch;
 
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
 use Mavinoo\LaravelBatch\Common\Helpers;
 
 class Batch

--- a/src/LaravelBatch.php
+++ b/src/LaravelBatch.php
@@ -2,84 +2,101 @@
 
 namespace Mavinoo\LaravelBatch;
 
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Mavinoo\LaravelBatch\Common\Helpers;
 
 class Batch
 {
     /**
+     * @var DatabaseManager
+     */
+    protected $db;
+
+    public function __construct(DatabaseManager $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
      * Update multiple rows
-     * @param string $table Table
-     * @param array $values Values
-     * @param string $index Index
+     * @param Model $table
+     * @param array $values
+     * @param string $index
+     * @updatedBy Ibrahim Sakr <ebrahimes@gmail.com>
      *
+     * @desc
      * Example
-     *
      * $table = 'users';
      * $value = [
-     *      [
-     *          'id' => 1,
-     *          'status' => 'active',
-     *          'nickname' => 'Mohammad'
-     *      ] ,
-     *      [
-     *          'id' => 5,
-     *          'status' => 'deactive',
-     *          'nickname' => 'Ghanbari'
-     *      ] ,
+     *     [
+     *         'id' => 1,
+     *         'status' => 'active',
+     *         'nickname' => 'Mohammad'
+     *     ] ,
+     *     [
+     *         'id' => 5,
+     *         'status' => 'deactive',
+     *         'nickname' => 'Ghanbari'
+     *     ] ,
      * ];
-     *
      * $index = 'id';
      *
-     * @return mixed
+     * @return bool|int
      */
-    public function update($table, $values, $index)
+    public function update(Model $table, array $values, string $index)
     {
-        $final  = array();
-        $ids    = array();
+        $final = array();
+        $ids = array();
 
-        if(!count($values))
+        if (!count($values))
             return false;
-        if(!isset($index) AND empty($index))
+        if (!isset($index) AND empty($index))
             return false;
 
-        foreach ($values as $key => $val)
-        {
+        foreach ($values as $key => $val) {
             $ids[] = $val[$index];
-            foreach (array_keys($val) as $field)
-            {
-                if ($field !== $index)
-                {
-                    $value           = (is_null($val[$field]) ? 'NULL' : '"' . Helpers::mysql_escape($val[$field]) . '"');
-                    $final[$field][] = 'WHEN `'. $index .'` = "' . $val[$index] . '" THEN ' . $value . ' ';
+            foreach (array_keys($val) as $field) {
+                if ($field !== $index) {
+                    $value = (is_null($val[$field]) ? 'NULL' : '"' . Helpers::mysql_escape($val[$field]) . '"');
+                    $final[$field][] = 'WHEN `' . $index . '` = "' . $val[$index] . '" THEN ' . $value . ' ';
                 }
             }
         }
 
         $cases = '';
-        foreach ($final as $k => $v)
-        {
-            $cases .=  '`'. $k.'` = (CASE '. implode("\n", $v) . "\n"
-                            . 'ELSE `'.$k.'` END), ';
+        foreach ($final as $k => $v) {
+            $cases .= '`' . $k . '` = (CASE ' . implode("\n", $v) . "\n"
+                . 'ELSE `' . $k . '` END), ';
         }
 
-        $query = "UPDATE `$table` SET " . substr($cases, 0, -2) . " WHERE `$index` IN(" . '"' . implode('","', $ids) . '"' . ");";
+        $query = "UPDATE `" . $this->getFullTableName($table) . "` SET " . substr($cases, 0, -2) . " WHERE `$index` IN(" . '"' . implode('","', $ids) . '"' . ");";
 
-        return DB::statement($query);
+        return $this->db->connection($this->getConnectionName($table))->update($query);
     }
 
+    /**
+     *
+
+
+     *
+     */
 
     /**
      * Insert Multi rows
-     * $table String
-     * $columns Array
-     * $values Array
-     * $batchSize Int
+     * @param Model $table
+     * @param array $columns
+     * @param array $values
+     * @param int $batchSize
+     * @return bool|mixed
+     * @throws \Throwable
+     * @updatedBy Ibrahim Sakr <ebrahimes@gmail.com>
      *
+     * @desc
      * Example
      *
      * $table = 'users';
-     *
      * $columns = [
      *      'firstName',
      *      'lastName',
@@ -87,101 +104,109 @@ class Batch
      *      'isActive',
      *      'status',
      * ];
-     *
      * $values = [
-     *      [
-     *          'Mohammad',
-     *          'Ghanbari',
-     *          'emailSample_1@gmail.com',
-     *          '1',
-     *          '0',
-     *      ] ,
-     *      [
-     *          'Saeed',
-     *          'Mohammadi',
-     *          'emailSample_2@gmail.com',
-     *          '1',
-     *          '0',
-     *      ] ,
-     *      [
-     *          'Avin',
-     *          'Ghanbari',
-     *          'emailSample_3@gmail.com',
-     *          '1',
-     *          '0',
-     *      ] ,
+     *     [
+     *         'Mohammad',
+     *         'Ghanbari',
+     *         'emailSample_1@gmail.com',
+     *         '1',
+     *         '0',
+     *     ] ,
+     *     [
+     *         'Saeed',
+     *         'Mohammadi',
+     *         'emailSample_2@gmail.com',
+     *         '1',
+     *         '0',
+     *     ] ,
+     *     [
+     *         'Avin',
+     *         'Ghanbari',
+     *         'emailSample_3@gmail.com',
+     *         '1',
+     *         '0',
+     *     ] ,
      * ];
-     *
      * $batchSize = 500; // insert 500 (default), 100 minimum rows in one query
-     *
      */
-    public function insert($table, $columns, $values, $batchSize = 500)
+    public function insert(Model $table, array $columns, array $values, int $batchSize = 500)
     {
-        if(!isset($table) AND empty($table))
+        // no need for the old validation since we now use type hint that supports from php 7.0
+        // but I kept this one
+        if (count($columns) != count($values[0])) {
             return false;
+        }
 
-        if(!count($values))
-            return false;
+        $query = [];
+        $minChunck = 100;
 
-        if(!count($columns))
-            return false;
+        $totalValues = count($values);
+        $batchSizeInsert = ($totalValues < $batchSize && $batchSize < $minChunck) ? $minChunck : $batchSize;
 
-        if(count($columns) != count($values[0]))
-            return false;
+        $totalChunk = ($batchSizeInsert < $minChunck) ? $minChunck : $batchSizeInsert;
 
+        $values = array_chunk($values, $totalChunk, true);
 
-        $minChunck          = 100;
+        foreach ($columns as $key => $column) {
+            $columns[$key] = "`" . Helpers::mysql_escape($column) . "`";
+        }
 
-        $totalValues        = count($values);
-        $batchSizeInsert    = ($totalValues < $batchSize AND $batchSize < $minChunck) ? $minChunck : $batchSize;
-
-        $totalChunk         = ($batchSizeInsert < $minChunck) ? $minChunck : $batchSizeInsert;
-
-        $values             = array_chunk($values, $totalChunk,true);
-
-
-        foreach ($columns as $key => $column)
-            $columns[$key]  = "`" . Helpers::mysql_escape($column) ."`";
-
-
-        $query              = [];
-        foreach ($values as $value)
-        {
+        foreach ($values as $value) {
             $valueArray = [];
-            foreach ($value as $data)
-            {
-                foreach ($data as $key => $item)
-                {
-                    $item = is_null($item) ? 'NULL' : "'" . Helpers::mysql_escape($item) ."'";
-                    $data[$key]  = $item;
+            foreach ($value as $data) {
+                foreach ($data as $key => $item) {
+                    $item = is_null($item) ? 'NULL' : "'" . Helpers::mysql_escape($item) . "'";
+                    $data[$key] = $item;
                 }
 
-                $valueArray[] =  '(' . implode(',', $data) . ')';
+                $valueArray[] = '(' . implode(',', $data) . ')';
             }
 
             $valueString = implode(', ', $valueArray);
 
-            $query []= "INSERT INTO `$table` (".implode(',', $columns).") VALUES $valueString;";
+            $query [] = "INSERT INTO `$table` (" . implode(',', $columns) . ") VALUES $valueString;";
 
         }
 
-        if(count($query))
-        {
-            return DB::transaction(function () use ($totalValues, $totalChunk, $query) {
+        if (count($query)) {
+            return $this->db->transaction(function () use ($totalValues, $totalChunk, $query) {
 
                 $totalQuery = 0;
-                foreach ($query as $value)
-                    $totalQuery += DB::statement($value) ? 1 : 0;
+                foreach ($query as $value) {
+                    $totalQuery += $this->db->statement($value) ? 1 : 0;
+                }
 
                 return [
-                    'totalRows'     =>  $totalValues,
-                    'totalBatch'    =>  $totalChunk,
-                    'totalQuery'    =>  $totalQuery
+                    'totalRows' => $totalValues,
+                    'totalBatch' => $totalChunk,
+                    'totalQuery' => $totalQuery
                 ];
-
             });
         }
 
         return false;
+    }
+
+    /**
+     * @param Model $model
+     * @return string
+     * @author Ibrahim Sakr <ebrahimes@gmail.com>
+     */
+    private function getFullTableName(Model $model)
+    {
+        return $model->getConnection()->getTablePrefix() . $model->getTable();
+    }
+
+    /**
+     * @param Model $model
+     * @return string|null
+     * @author Ibrahim Sakr <ebrahimes@gmail.com>
+     */
+    private function getConnectionName(Model $model)
+    {
+        if (!is_null($cn = $model->getConnectionName()))
+            return $cn;
+
+        return $model->getConnection()->getName();
     }
 }

--- a/src/LaravelBatch.php
+++ b/src/LaravelBatch.php
@@ -47,13 +47,15 @@ class Batch
      */
     public function update(Model $table, array $values, string $index)
     {
-        $final = array();
-        $ids = array();
+        $final = [];
+        $ids = [];
 
-        if (!count($values))
+        if (!count($values)) {
             return false;
-        if (!isset($index) AND empty($index))
+        }
+        if (!isset($index) && empty($index)) {
             return false;
+        }
 
         foreach ($values as $key => $val) {
             $ids[] = $val[$index];
@@ -75,13 +77,6 @@ class Batch
 
         return $this->db->connection($this->getConnectionName($table))->update($query);
     }
-
-    /**
-     *
-
-
-     *
-     */
 
     /**
      * Insert Multi rows


### PR DESCRIPTION
I used this lib for my work and when I did I noticed that it uses the table name as a string and this have 
a lot of downsides such as multiple connections which I faced in my case

so I updated the lib with
- new standards for PHP 7 (using the params type hint)
- using DatabaseManager to access DB instead of Facade for those who use Lumen without Facades
- passing Table as Eloquent Model instead of string so we can get the correct name even with prefixes and the correct connection

I hope anyone finds this useful