### PR TITLE
add ability to use raw query for update function

### DIFF
--- a/src/InterfaceBatch.php
+++ b/src/InterfaceBatch.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 interface InterfaceBatch
 {
-    public function update(Model $table, array $values, string $index = null);
+    public function update(Model $table, array $values, string $index = null, bool $raw = false);
 
     public function insert(Model $table, array $columns, array $values, int $batchSize = 500);
 }

--- a/src/LaravelBatch.php
+++ b/src/LaravelBatch.php
@@ -44,7 +44,7 @@ class Batch implements InterfaceBatch
      *
      * @return bool|int
      */
-    public function update(Model $table, array $values, string $index = null)
+    public function update(Model $table, array $values, string $index = null, bool $raw = false)
     {
         $final = [];
         $ids = [];
@@ -52,7 +52,7 @@ class Batch implements InterfaceBatch
         if (!count($values)) {
             return false;
         }
-        
+
         if (!isset($index) || empty($index)) {
             $index = $table->getKeyName();
         }
@@ -61,7 +61,8 @@ class Batch implements InterfaceBatch
             $ids[] = $val[$index];
             foreach (array_keys($val) as $field) {
                 if ($field !== $index) {
-                    $value = (is_null($val[$field]) ? 'NULL' : '"' . Common::mysql_escape($val[$field]) . '"');
+                    $finalField = $raw ? Common::mysql_escape($val[$field]) : '"' . Common::mysql_escape($val[$field]) . '"';
+                    $value = (is_null($val[$field]) ? 'NULL' : $finalField);
                     $final[$field][] = 'WHEN `' . $index . '` = "' . $val[$index] . '" THEN ' . $value . ' ';
                 }
             }
@@ -159,8 +160,7 @@ class Batch implements InterfaceBatch
 
             $valueString = implode(', ', $valueArray);
 
-            $query [] = "INSERT INTO `" . $this->getFullTableName($table) . "` (" . implode(',', $columns) . ") VALUES $valueString;";
-
+            $query[] = "INSERT INTO `" . $this->getFullTableName($table) . "` (" . implode(',', $columns) . ") VALUES $valueString;";
         }
 
         if (count($query)) {


### PR DESCRIPTION
My personal project has use case where i need to batch update a column with sum result from another column value. So I think it's could be useful for this awesome library to have such functionality.

My sample codes are as follow.

```
$values = [
    [
       'code' => 'ORDER001',
       'count' => DB::raw("`count` + 1"),
    ],
    [
       'code' => 'ORDER002',
       'count' => DB::raw("`count` + 1"),
    ],
 ];

$orderInstance = new Order;
$index = 'code';
$raw = true;
batch()->update($orderInstance, $values, $index, $raw);
```