### PR TITLE
Checks database connection on insert method

### DIFF
--- a/src/LaravelBatch.php
+++ b/src/LaravelBatch.php
@@ -164,11 +164,11 @@ class Batch implements InterfaceBatch
         }
 
         if (count($query)) {
-            return $this->db->transaction(function () use ($totalValues, $totalChunk, $query) {
+            return $this->db->transaction(function () use ($totalValues, $totalChunk, $query, $table) {
 
                 $totalQuery = 0;
                 foreach ($query as $value) {
-                    $totalQuery += $this->db->statement($value) ? 1 : 0;
+                    $totalQuery += $this->db->connection($this->getConnectionName($table))->statement($value) ? 1 : 0;
                 }
 
                 return [


### PR DESCRIPTION
I'm having issues with batch inserts when a model uses a db connection different than the default (specified in the $connection variable in the model). It throws an error on insert because it tries to find the table in the default connection - the update method gets the connection using getConnectionName(), but the insert method doesn't.