### PR TITLE
Batch Update with two matching conditions

### DIFF
--- a/src/LaravelBatch.php
+++ b/src/LaravelBatch.php
@@ -80,6 +80,67 @@ class Batch implements InterfaceBatch
     }
 
     /**
+     * Update multiple rows
+     * @param Model $table
+     * @param array $values
+     * @param string $index
+     * @updatedBy Ibrahim Sakr <ebrahimes@gmail.com>
+     *
+     * @desc
+     * Example
+     * $table = 'users';
+     * $value = [
+     *     [
+     *         'id' => 1,
+     *         'status' => 'active',
+     *         'nickname' => 'Mohammad'
+     *     ] ,
+     *     [
+     *         'id' => 5,
+     *         'status' => 'deactive',
+     *         'nickname' => 'Ghanbari'
+     *     ] ,
+     * ];
+     * $index = 'id';
+     * $index = 'user_id';
+     *
+     * @return bool|int
+     */
+    public function updateWithTwoIndex(Model $table, array $values, string $index = null, string $index2 = null, bool $raw = false)
+    {
+        $final = [];
+        $ids = [];
+
+        if (!count($values)) {
+            return false;
+        }
+
+        if (!isset($index) || empty($index)) {
+            $index = $table->getKeyName();
+        }
+
+        foreach ($values as $key => $val) {
+            $ids[] =  $val[$index];
+            $ids2[] = $val[$index2];
+            foreach (array_keys($val) as $field) {
+                if ($field !== $index || $field !== $index2 ) {
+                    $finalField = $raw ? Common::mysql_escape($val[$field]) : '"' . Common::mysql_escape($val[$field]) . '"';
+                    $value = (is_null($val[$field]) ? 'NULL' : $finalField);
+                    $final[$field][] = 'WHEN (`' . $index . '` = "' . Common::mysql_escape($val[$index]) .'" AND `'. $index2 . '` = "' . $val[$index2] .'") THEN ' . $value . ' ';
+                }
+            }
+        }
+
+        $cases = '';
+        foreach ($final as $k => $v) {
+            $cases .= '`' . $k . '` = (CASE ' . implode("\n", $v) . "\n"
+                      . 'ELSE `' . $k . '` END), ';
+        }
+        $query = "UPDATE `" . $this->getFullTableName($table) . "` SET " . substr($cases, 0, -2) . " WHERE `$index` IN(" . '"' . implode('","', $ids) . '")' .  " AND `$index2` IN(" . '"' . implode('","', $ids2) . '"' ." );";
+
+        return $this->db->connection($this->getConnectionName($table))->update($query);
+    }
+    /**
      * Insert Multi rows
      * @param Model $table
      * @param array $columns

--- a/src/LaravelBatch.php
+++ b/src/LaravelBatch.php
@@ -102,7 +102,7 @@ class Batch implements InterfaceBatch
      *     ] ,
      * ];
      * $index = 'id';
-     * $index = 'user_id';
+     * $index2 = 'user_id';
      *
      * @return bool|int
      */


### PR DESCRIPTION
Modified the existing update function to a new function as a requirement of matching with two columns values. This may be helpful as a quick requirement. I didn't create up the dynamic numbers for matching but only one extra index.

WHEN (CONDITION1 AND CONDITION2) THEN VALUE.

USING THE BATCH HELPER IT WILL BE LIKE: -

$updateIndex1 = 'id';
$updateIndex2 = 'user_id';
batch()->updateWithTwoIndex($userTickerMappingModel, $updatedTicketData,$updateIndex1, $updateIndex2);