### PR TITLE
[Fix] fix wrong values of type boolean

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -74,7 +74,7 @@ class Batch implements BatchInterface
             foreach (array_keys($val) as $field) {
                 if ($field !== $index) {
                     $finalField = $raw ? Common::mysql_escape($val[$field]) : "'" . Common::mysql_escape($val[$field]) . "'";
-                    $value = (is_null($val[$field]) ? 'NULL' : Common::convertBoolean($finalField));
+                    $value = (is_null($val[$field]) ? 'NULL' : $finalField);
                     if ($driver == 'pgsql')
                         $final[$field][] = 'WHEN ' . $index . ' = \'' . $val[$index] . '\' THEN ' . $value . ' ';
                     else

--- a/src/Batch.php
+++ b/src/Batch.php
@@ -74,7 +74,7 @@ class Batch implements BatchInterface
             foreach (array_keys($val) as $field) {
                 if ($field !== $index) {
                     $finalField = $raw ? Common::mysql_escape($val[$field]) : "'" . Common::mysql_escape($val[$field]) . "'";
-                    $value = (is_null($val[$field]) ? 'NULL' : $finalField);
+                    $value = (is_null($val[$field]) ? 'NULL' : Common::convertBoolean($finalField));
                     if ($driver == 'pgsql')
                         $final[$field][] = 'WHEN ' . $index . ' = \'' . $val[$index] . '\' THEN ' . $value . ' ';
                     else

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -26,4 +26,23 @@ class Common
 
         return $fieldValue;
     }
+
+    /**
+     * Convert boolean values to 0 or 1.
+     *
+     * @param $fieldValue
+     * @return array|string|bool|string[]|bool[]
+     */
+    public static function convertBoolean($fieldValue)
+    {
+        if (is_array($fieldValue)) {
+            return array_map(__METHOD__, $fieldValue);
+        }
+
+        if (is_bool($fieldValue)) {
+            return (int) $fieldValue;
+        }
+
+        return $fieldValue;
+    }
 }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -16,6 +16,10 @@ class Common
             return array_map(__METHOD__, $fieldValue);
         }
 
+        if (is_bool($fieldValue)) {
+            return (int) $fieldValue;
+        }
+
         if (!empty($fieldValue) && is_string($fieldValue)) {
             return str_replace(
                 ['\\', "\0", "\n", "\r", "'", '"', "\x1a"],

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -30,23 +30,4 @@ class Common
 
         return $fieldValue;
     }
-
-    /**
-     * Convert boolean values to 0 or 1.
-     *
-     * @param $fieldValue
-     * @return array|string|bool|string[]|bool[]
-     */
-    public static function convertBoolean($fieldValue)
-    {
-        if (is_array($fieldValue)) {
-            return array_map(__METHOD__, $fieldValue);
-        }
-
-        if (is_bool($fieldValue)) {
-            return (int) $fieldValue;
-        }
-
-        return $fieldValue;
-    }
 }

--- a/tests/BatchInsertTest.php
+++ b/tests/BatchInsertTest.php
@@ -11,6 +11,7 @@ class BatchInsertTest extends BootstrapDatabase
         'password',
         'name',
         'status',
+        'is_vip'
     ];
 
     public function testBatchInsertWithFacade()
@@ -20,19 +21,22 @@ class BatchInsertTest extends BootstrapDatabase
                 'djunehor@gmail.com',
                 bcrypt('djunehor'),
                 'djunehor',
-                'active'
+                'active',
+                true,
             ],
             [
                 'samuel@gmail.com',
                 bcrypt('samuel'),
                 'samuel',
-                'whodey'
+                'whodey',
+                false,
             ],
             [
                 'general@gmail.com',
                 bcrypt('general'),
                 'general',
                 'inactive',
+                false,
             ]
         ];
         $batchSize = 500; // insert 500 (default), 100 minimum rows in one query
@@ -59,12 +63,13 @@ class BatchInsertTest extends BootstrapDatabase
                 'djunehor@gmail.com',
                 bcrypt('djunehor'),
                 'djunehor',
+                'active',
             ],
             [
                 'samuel@gmail.com',
                 bcrypt('samuel'),
                 'samuel',
-                'whodey'
+                'whodey',
             ],
             [
                 'general@gmail.com',
@@ -86,19 +91,22 @@ class BatchInsertTest extends BootstrapDatabase
                 'djunehor@gmail.com',
                 bcrypt('djunehor'),
                 'djunehor',
-                'active'
+                'active',
+                true,
             ],
             [
                 'samuel@gmail.com',
                 bcrypt('samuel'),
                 'samuel',
-                'whodey'
+                'whodey',
+                false,
             ],
             [
                 'general@gmail.com',
                 bcrypt('general'),
                 'general',
                 'inactive',
+                false,
             ]
         ];
         $batchSize = 500; // insert 500 (default), 100 minimum rows in one query

--- a/tests/BatchUpdateTest.php
+++ b/tests/BatchUpdateTest.php
@@ -12,6 +12,7 @@ class BatchUpdateTest extends BootstrapDatabase
         'password',
         'name',
         'status',
+        'is_vip',
     ];
 
     private function insert()
@@ -21,19 +22,22 @@ class BatchUpdateTest extends BootstrapDatabase
                 'djunehor@gmail.com',
                 bcrypt('djunehor'),
                 'djunehor',
-                'active'
+                'active',
+                true,
             ],
             [
                 'samuel@gmail.com',
                 bcrypt('samuel'),
                 'samuel',
-                'whodey'
+                'whodey',
+                false,
             ],
             [
                 'general@gmail.com',
                 bcrypt('general'),
                 'general',
                 'inactive',
+                false,
             ]
         ];
         $batchSize = 500; // insert 500 (default), 100 minimum rows in one query
@@ -51,7 +55,8 @@ class BatchUpdateTest extends BootstrapDatabase
         $columnValues = [
             [
                 'id' => 1,
-                'status' => 'amala'
+                'name' => 'amala',
+                'is_vip' => false
             ],
             [
                 'id' => 2,
@@ -68,7 +73,12 @@ class BatchUpdateTest extends BootstrapDatabase
 
         $result = Batch::update($this->model, $columnValues, $index);
 
+        $member = $this->model->findOrFail(1);
+
         $this->assertTrue($result === 3);
+        $this->assertEquals('amala', $member->name);
+        $this->assertFalse($member->is_vip);
+
         $this->model->truncate();
     }
 
@@ -78,7 +88,8 @@ class BatchUpdateTest extends BootstrapDatabase
         $columnValues = [
             [
                 'id' => 1,
-                'status' => 'amala'
+                'name' => 'amala',
+                'is_vip' => false
             ],
             [
                 'id' => 2,
@@ -95,7 +106,12 @@ class BatchUpdateTest extends BootstrapDatabase
 
         $result = batch()->update($this->model, $columnValues, $index);
 
+        $member = $this->model->findOrFail(1);
+
         $this->assertTrue($result === 3);
+        $this->assertEquals('amala', $member->name);
+        $this->assertFalse($member->is_vip);
+
         $this->model->truncate();
     }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -4,6 +4,10 @@ class TestModel extends \Illuminate\Database\Eloquent\Model
 {
     protected $table = 'HmKTjCJgLN9bBq7KXzI3';
 
+    protected $casts = [
+        'is_vip' => 'boolean'
+    ];
+
     /**
      * Get name of the table.
      *


### PR DESCRIPTION
Hi there,

When you try to batch insert/update a boolean-type value, a `false` value will be converted to empty string which leads to failure in mysql query.

```php
$final[$field][] = 'WHEN `' . $index . '` = \'' . $val[$index] . '\' THEN ' . $value . ' ';
```

So in this pull request, I convert the boolean values to 1 or 0 in `mysql_escape` function to prevent this error.

```php
if (is_bool($fieldValue)) {
    return (int) $fieldValue;
}
```

All the best~