### PR TITLE
Single quotes in json data | bug

### DIFF
--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -21,11 +21,11 @@ class Common
         }
 
         if(self::is_json($fieldValue)){
-            return self::safeString($fieldValue);
+            return self::safeJson($fieldValue);
         }
 
         if (!empty($fieldValue) && is_string($fieldValue)) {
-            return self::safeJson($fieldValue);
+            return self::safeString($fieldValue);
         }
 
         return $fieldValue;

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -55,7 +55,6 @@ class Common
         $jsonData = json_decode($jsonData,true);
         $safeJsonData = [];
         foreach ($jsonData as $key => $value){
-            var_dump($value);
             if (self::is_json($value)){
                 $safeJsonData[$key] = self::safeJson($value,true);
             }elseif(is_string($value)){
@@ -68,6 +67,5 @@ class Common
         }
         return $asArray ? $safeJsonData : json_encode($safeJsonData);
     }
-
 
 }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -54,6 +54,9 @@ class Common
     protected static function safeJson($jsonData,$asArray = false){
         $jsonData = json_decode($jsonData,true);
         $safeJsonData = [];
+        if (!is_array($jsonData)){
+            return $jsonData;
+        }
         foreach ($jsonData as $key => $value){
             if (self::is_json($value)){
                 $safeJsonData[$key] = self::safeJson($value,true);

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -25,16 +25,20 @@ class Common
         }
 
         if (!empty($fieldValue) && is_string($fieldValue)) {
-            return self::safeString($fieldValue);
+            return str_replace(
+                ['\\', "\0", "\n", "\r", "'", '"', "\x1a"],
+                ['\\\\', '\\0', '\\n', '\\r', "\\'", '\\"', '\\Z'],
+                $fieldValue
+            );
         }
 
         return $fieldValue;
     }
 
-    protected static function safeString($fieldValue){
+    protected static function safeJsonString($fieldValue){
         return str_replace(
-            ['\\', "\0", "\n", "\r", "'", '"', "\x1a"],
-            ['\\\\', '\\0', '\\n', '\\r', "\\'", '\\"', '\\Z'],
+            ["'"],
+            ["\'"],
             $fieldValue
         );
     }
@@ -54,7 +58,7 @@ class Common
             if (self::is_json($value)){
                 $safeJsonData[$key] = self::safeJson($jsonData,true);
             }elseif(is_string($value)){
-                $safeJsonData[$key] = self::safeString($value);
+                $safeJsonData[$key] = self::safeJsonString($value);
             }else{
                 $safeJsonData[$key] = $value;
             }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -58,7 +58,7 @@ class Common
             if (self::is_json($value)){
                 $safeJsonData[$key] = self::safeJson($jsonData,true);
             }elseif(is_string($value)){
-                $safeJsonData[$key] = $value;
+                $safeJsonData[$key] = self::safeJsonString($value);
             }else{
                 $safeJsonData[$key] = $value;
             }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -55,10 +55,13 @@ class Common
         $jsonData = json_decode($jsonData,true);
         $safeJsonData = [];
         foreach ($jsonData as $key => $value){
+            var_dump($value);
             if (self::is_json($value)){
-                $safeJsonData[$key] = self::safeJson($jsonData,true);
+                $safeJsonData[$key] = self::safeJson($value,true);
             }elseif(is_string($value)){
                 $safeJsonData[$key] = self::safeJsonString($value);
+            }elseif(is_array($value)){
+                $safeJsonData[$key] = self::safeJson(json_encode($value),true);
             }else{
                 $safeJsonData[$key] = $value;
             }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -38,7 +38,7 @@ class Common
     protected static function safeJsonString($fieldValue){
         return str_replace(
             ["'"],
-            ["\\'"],
+            ["''"],
             $fieldValue
         );
     }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -58,7 +58,7 @@ class Common
             if (self::is_json($value)){
                 $safeJsonData[$key] = self::safeJson($jsonData,true);
             }elseif(is_string($value)){
-                $safeJsonData[$key] = self::safeJsonString($value);
+                $safeJsonData[$key] = $value;
             }else{
                 $safeJsonData[$key] = $value;
             }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -21,7 +21,7 @@ class Common
         }
 
         if(self::is_json($fieldValue)){
-            return $fieldValue;
+            return self::safeJson($fieldValue);
         }
 
         if (!empty($fieldValue) && is_string($fieldValue)) {
@@ -38,7 +38,7 @@ class Common
     protected static function safeJsonString($fieldValue){
         return str_replace(
             ["'"],
-            ["\'"],
+            ["\\'"],
             $fieldValue
         );
     }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -69,4 +69,5 @@ class Common
         return $asArray ? $safeJsonData : json_encode($safeJsonData);
     }
 
+
 }

--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -21,7 +21,7 @@ class Common
         }
 
         if(self::is_json($fieldValue)){
-            return self::safeJson($fieldValue);
+            return $fieldValue;
         }
 
         if (!empty($fieldValue) && is_string($fieldValue)) {


### PR DESCRIPTION
A syntax error occurs when updating a single-quote json data in the database. I tested it for PostgreSQL and it was successful.