### PR TITLE
Hotfix for is_json function.

### DIFF
--- a/src/Common/Common.php
+++ b/src/Common/Common.php
@@ -60,7 +60,8 @@ class Common
         if (!is_string($str)) {
             return false;
         }
-        return json_decode($str, true) !== null;
+        $json = json_decode($str);
+        return $json && $str != $json;
     }
 
     protected static function safeJson($jsonData, $asArray = false)


### PR DESCRIPTION
 Last version of this function will return true for any number also, and will convert any big numeric string into their scientific notation.