### PR TITLE
Determine database driver from model

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -65,8 +65,7 @@ class Batch implements BatchInterface
             $index = $table->getKeyName();
         }
 
-        $connection = config('database.default');
-        $driver = config("database.connections.{$connection}.driver");
+        $driver = $table->getConnection()->getDriverName();
 
         foreach ($values as $key => $val) {
             $ids[] = $val[$index];
@@ -174,8 +173,7 @@ class Batch implements BatchInterface
     {
         $final = [];
         $ids = [];
-        $connection = config('database.default');
-        $driver = config("database.connections.{$connection}.driver");
+        $driver = $table->getConnection()->getDriverName();
 
         if (!count($values)) {
             return false;
@@ -320,8 +318,7 @@ class Batch implements BatchInterface
             }
         }
 
-        $connection = config('database.default');
-        $driver = config("database.connections.{$connection}.driver");
+        $driver = $table->getConnection()->getDriverName();
 
         if (Common::disableBacktick($driver)) {
             foreach ($columns as $key => $column) {


### PR DESCRIPTION
The current implementation determines the database driver from the default database configuration file. This can cause issues when a model uses a database that is different from the default. This pull request fixes this by determining the driver based on the model configuration, using methods built into the framework.

```php
$driver = $table->getConnection()->getDriverName();
```

I believe this to be a fix that brings it into alignment with expectations, but there's a slim chance it could cause breaking changes if people were relying on the existing behavior.

I was unable to get the tests running on a fresh Laravel project and therefore did not check existing tests or add an additional test for this use case. In practice, it was working for me though.