### PR TITLE
Feature/prevent index columns from being updated and properly quote string values

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -188,7 +188,8 @@ class Batch implements BatchInterface
             $ids[] = $val[$index];
             $ids2[] = $val[$index2];
             foreach (array_keys($val) as $field) {
-                if ($field !== $index || $field !== $index2) {
+                // FIX: use AND so we skip fields that equal index OR index2
+            if ($field !== $index && $field !== $index2) {
                     $finalField = $raw ? Common::mysql_escape($val[$field]) : "'" . Common::mysql_escape($val[$field]) . "'";
                     $value = (is_null($val[$field]) ? 'NULL' : $finalField);
 


### PR DESCRIPTION


…condition

The condition $field !== $index || $field !== $index2 was always true, causing index columns to be included in CASE updates. Replaced with AND to properly skip both index fields.
